### PR TITLE
Fix: Improve local development setup and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ git clone https://github.com/easychen/not-only-fans.git
 cd not-only-fans
 docker-compose up -d --build
 ```
+The database is initialized when the container starts for the first time. If you need to re-initialize, you may need to remove the Docker volume for the database and restart the containers.
 
 ### Initialize project data 
 
@@ -92,7 +93,7 @@ cd /app/client/ && yarn install && yarn build
 ### Initialize the API
 
 ```bash
-cd /app/api/ && composer install && mkdir /app/api/storage && chmod -R 0777 /app/api/storage
+cd /app/api/ && composer install
 ```
 
 ### Domain pointing

--- a/docker/app/dockerfile
+++ b/docker/app/dockerfile
@@ -1,4 +1,4 @@
-FROM webdevops/php-apache:7.4-alpine
+FROM webdevops/php-apache:8.1-alpine
 
 # Environment variables for Node.js
 ENV NODE_VERSION 18.18.0
@@ -6,5 +6,7 @@ ENV PATH /usr/local/bin:$PATH
 
 # Install Node.js and Yarn
 RUN apk add --no-cache curl \            && curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \            && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \            && ln -s /usr/local/bin/node /usr/local/bin/nodejs \            && npm config set unsafe-perm true \            && npm install -g yarn \            && apk del curl \            && rm -rf /tmp/* /var/cache/apk/*
+
+RUN mkdir -p /app/api/storage && chown application:application /app/api/storage
 
 COPY vhost.conf /opt/docker/etc/httpd/vhost.conf

--- a/www/client/.env.development
+++ b/www/client/.env.development
@@ -1,3 +1,3 @@
-REACT_APP_API_BASE = 'http://dd.ftqq.com:8088/'
-REACT_APP_WEBSOCKECT = 'ws://localhost:9501'
+REACT_APP_API_BASE = 'http://api.notonlyfans.vip/'
+REACT_APP_WEBSOCKECT = 'ws://api.notonlyfans.vip:9501'
 REACT_APP_CONTRACT = '0xf6351b9af2da7f8613c6763b42feedae6441f309'


### PR DESCRIPTION
This commit addresses several issues to enhance the local development experience:

1.  **PHP Version:** Updated the Dockerfile for the app service (`docker/app/dockerfile`) to use `webdevops/php-apache:8.1-alpine` instead of `7.4-alpine`. This resolves the version mismatch with the backend's `composer.json` requirement (PHP 8.1).

2.  **API Storage Directory:**
    *   Modified `docker/app/dockerfile` to automatically create the `/app/api/storage` directory and set appropriate ownership (`application:application`).
    *   Removed the manual `mkdir ... && chmod 777 ...` command for this directory from the `README.md` as it's now handled by the Docker build and with better permissions.

3.  **README Clarity:**
    *   Added a note to `README.md` regarding database initialization timing during the first Docker startup.

4.  **Client Development Environment:**
    *   Updated `www/client/.env.development` to set `REACT_APP_API_BASE` to `http://api.notonlyfans.vip/` (from an external address).
    *   Updated `REACT_APP_WEBSOCKECT` in `www/client/.env.development` to `ws://api.notonlyfans.vip:9501/` to align with local domain usage.
    These changes ensure that using `yarn start` for client development correctly connects to the local Dockerized backend.

These improvements aim to make the local setup process smoother and more aligned with the project's requirements, allowing you to test the project more easily by following the README.